### PR TITLE
feat: limit the number of results

### DIFF
--- a/qqmlsortfilterproxymodel.cpp
+++ b/qqmlsortfilterproxymodel.cpp
@@ -53,6 +53,30 @@ int QQmlSortFilterProxyModel::count() const
 }
 
 /*!
+    \qmlproperty int SortFilterProxyModel::limit
+
+   Limit the total number of results
+*/
+int QQmlSortFilterProxyModel::limit() const
+{
+    return m_limit;
+}
+
+void QQmlSortFilterProxyModel::setLimit(int newLimit)
+{
+    if (m_limit == newLimit)
+        return;
+
+    const auto prevCount = count();
+    m_limit = newLimit;
+    emit limitChanged();
+
+    if (prevCount != count()) {
+        emit countChanged();
+    }
+}
+
+/*!
     \qmlproperty bool SortFilterProxyModel::delayed
 
     Delay the execution of filters, sorters and proxyRoles until the next event loop.
@@ -232,6 +256,14 @@ QVariant QQmlSortFilterProxyModel::sourceData(const QModelIndex &sourceIndex, in
         return proxyRole->roleData(sourceIndex, *this, proxyRolePair.second);
     else
         return sourceModel()->data(sourceIndex, role);
+}
+
+int QQmlSortFilterProxyModel::rowCount(const QModelIndex& parent) const
+{
+    const auto origLimit = QSortFilterProxyModel::rowCount(parent);
+    if (m_limit == -1)
+        return origLimit;
+    return qMin(m_limit, origLimit);
 }
 
 QVariant QQmlSortFilterProxyModel::data(const QModelIndex &index, int role) const

--- a/qqmlsortfilterproxymodel.cpp
+++ b/qqmlsortfilterproxymodel.cpp
@@ -208,11 +208,11 @@ void QQmlSortFilterProxyModel::componentComplete()
 {
     m_completed = true;
 
-    for (const auto& filter : m_filters)
+    for (const auto& filter : qAsConst(m_filters))
         filter->proxyModelCompleted(*this);
-    for (const auto& sorter : m_sorters)
+    for (const auto& sorter : qAsConst(m_sorters))
         sorter->proxyModelCompleted(*this);
-    for (const auto& proxyRole : m_proxyRoles)
+    for (const auto& proxyRole : qAsConst(m_proxyRoles))
         proxyRole->proxyModelCompleted(*this);
 
     invalidate();
@@ -266,7 +266,7 @@ QVariantMap QQmlSortFilterProxyModel::get(int row) const
     QVariantMap map;
     QModelIndex modelIndex = index(row, 0);
     QHash<int, QByteArray> roles = roleNames();
-    for (QHash<int, QByteArray>::const_iterator it = roles.begin(); it != roles.end(); ++it)
+    for (auto it = roles.cbegin(); it != roles.cend(); ++it)
         map.insert(it.value(), data(modelIndex, it.key()));
     return map;
 }
@@ -436,8 +436,9 @@ void QQmlSortFilterProxyModel::updateRoleNames()
     auto roles = m_roleNames.keys();
     auto maxIt = std::max_element(roles.cbegin(), roles.cend());
     int maxRole = maxIt != roles.cend() ? *maxIt : -1;
-    for (auto proxyRole : m_proxyRoles) {
-        for (auto roleName : proxyRole->names()) {
+    for (auto proxyRole : qAsConst(m_proxyRoles)) {
+        const auto proxyRoleNames = proxyRole->names();
+        for (const auto &roleName : proxyRoleNames) {
             ++maxRole;
             m_roleNames[maxRole] = roleName.toUtf8();
             m_proxyRoleMap[maxRole] = {proxyRole, roleName};
@@ -509,7 +510,7 @@ QVariantMap QQmlSortFilterProxyModel::modelDataMap(const QModelIndex& modelIndex
 {
     QVariantMap map;
     QHash<int, QByteArray> roles = roleNames();
-    for (QHash<int, QByteArray>::const_iterator it = roles.begin(); it != roles.end(); ++it)
+    for (auto it = roles.cbegin(); it != roles.cend(); ++it)
         map.insert(it.value(), sourceModel()->data(modelIndex, it.key()));
     return map;
 }

--- a/qqmlsortfilterproxymodel.h
+++ b/qqmlsortfilterproxymodel.h
@@ -23,6 +23,7 @@ class QQmlSortFilterProxyModel : public QSortFilterProxyModel,
 
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(bool delayed READ delayed WRITE setDelayed NOTIFY delayedChanged)
+    Q_PROPERTY(int limit READ limit WRITE setLimit NOTIFY limitChanged FINAL)
 
     Q_PROPERTY(QString filterRoleName READ filterRoleName WRITE setFilterRoleName NOTIFY filterRoleNameChanged)
     Q_PROPERTY(QString filterPattern READ filterPattern WRITE setFilterPattern NOTIFY filterPatternChanged)
@@ -93,6 +94,7 @@ public:
     void setSourceModel(QAbstractItemModel *sourceModel) override;
 
 Q_SIGNALS:
+    void limitChanged();
     void countChanged();
     void delayedChanged();
 
@@ -105,6 +107,7 @@ Q_SIGNALS:
     void ascendingSortOrderChanged();
 
 protected:
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
     bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
 
@@ -126,6 +129,9 @@ private Q_SLOTS:
     void invalidateProxyRoles();
 
 private:
+    int limit() const;
+    void setLimit(int newLimit);
+
     QVariantMap modelDataMap(const QModelIndex& modelIndex) const;
 
     void onFilterAppended(Filter* filter) override;
@@ -153,6 +159,7 @@ private:
     bool m_invalidateFilterQueued = false;
     bool m_invalidateQueued = false;
     bool m_invalidateProxyRolesQueued = false;
+    int m_limit{-1};
 };
 
 }


### PR DESCRIPTION
introduce a new property, `limit` that allows for narrowing down the number of returned results

usecase: give me list of 5 most valuable assets
```qml
tagsModel: SortFilterProxyModel {
    id: walletAccountAssetsModel
    sourceModel: assets
    limit: 5
    function filterPredicate(modelData) {
        return d.uniquePermissionTokenKeys.includes(modelData.symbol.toUpperCase())
    }
    filters: [
        ExpressionFilter {
            expression: walletAccountAssetsModel.filterPredicate(model)
        }
    ]
    sorters: ExpressionSorter {
        expression: {
            return modelLeft.enabledNetworkBalance.amount > modelRight.enabledNetworkBalance.amount // descending, biggest first
        }
    }
}
```

some minor fixes reported by clazy (separate commit)