### PR TITLE
Chore/revert limit and clazy fixes

### DIFF
--- a/filters/expressionfilter.cpp
+++ b/filters/expressionfilter.cpp
@@ -65,9 +65,9 @@ bool ExpressionFilter::filterRow(const QModelIndex& sourceIndex, const QQmlSortF
 
         for (auto it = roles.cbegin(); it != roles.cend(); ++it)
             addToContext(it.value(), proxyModel.sourceData(sourceIndex, it.key()));
-        addToContext("index", sourceIndex.row());
+        addToContext(QStringLiteral("index"), sourceIndex.row());
 
-        context.setContextProperty("model", modelMap);
+        context.setContextProperty(QStringLiteral("model"), modelMap);
 
         QQmlExpression expression(m_scriptString, &context);
         QVariant variantResult = expression.evaluate();
@@ -101,12 +101,13 @@ void ExpressionFilter::updateContext(const QQmlSortFilterProxyModel& proxyModel)
         modelMap.insert(name, value);
     };
 
-    for (const QByteArray& roleName : proxyModel.roleNames().values())
+    const auto roleNames = proxyModel.roleNames();
+    for (const QByteArray& roleName : roleNames)
         addToContext(roleName, QVariant());
 
-    addToContext("index", -1);
+    addToContext(QStringLiteral("index"), -1);
 
-    m_context->setContextProperty("model", modelMap);
+    m_context->setContextProperty(QStringLiteral("model"), modelMap);
     updateExpression();
 }
 
@@ -116,7 +117,7 @@ void ExpressionFilter::updateExpression()
         return;
 
     delete m_expression;
-    m_expression = new QQmlExpression(m_scriptString, m_context, 0, this);
+    m_expression = new QQmlExpression(m_scriptString, m_context, nullptr, this);
     connect(m_expression, &QQmlExpression::valueChanged, this, &ExpressionFilter::invalidate);
     m_expression->setNotifyOnValueChanged(true);
     m_expression->evaluate();

--- a/filters/filtercontainer.h
+++ b/filters/filtercontainer.h
@@ -3,7 +3,7 @@
 
 #include <QList>
 #include <QQmlListProperty>
-#include <qqml.h>
+#include <QQmlEngine>
 #include <QPointer>
 
 namespace qqsfpm {

--- a/filters/filtercontainerfilter.cpp
+++ b/filters/filtercontainerfilter.cpp
@@ -4,7 +4,7 @@ namespace qqsfpm {
 
 void FilterContainerFilter::proxyModelCompleted(const QQmlSortFilterProxyModel& proxyModel)
 {
-    for (Filter* filter : m_filters)
+    for (Filter* filter : qAsConst(m_filters))
         filter->proxyModelCompleted(proxyModel);
 }
 

--- a/filters/filtersqmltypes.cpp
+++ b/filters/filtersqmltypes.cpp
@@ -12,7 +12,7 @@
 namespace qqsfpm {
 
 void registerFiltersTypes() {
-    qmlRegisterUncreatableType<Filter>("SortFilterProxyModel", 0, 2, "Filter", "Filter is an abstract class");
+    qmlRegisterUncreatableType<Filter>("SortFilterProxyModel", 0, 2, "Filter", QStringLiteral("Filter is an abstract class"));
     qmlRegisterType<ValueFilter>("SortFilterProxyModel", 0, 2, "ValueFilter");
     qmlRegisterType<IndexFilter>("SortFilterProxyModel", 0, 2, "IndexFilter");
     qmlRegisterType<RegExpFilter>("SortFilterProxyModel", 0, 2, "RegExpFilter");
@@ -20,7 +20,7 @@ void registerFiltersTypes() {
     qmlRegisterType<ExpressionFilter>("SortFilterProxyModel", 0, 2, "ExpressionFilter");
     qmlRegisterType<AnyOfFilter>("SortFilterProxyModel", 0, 2, "AnyOf");
     qmlRegisterType<AllOfFilter>("SortFilterProxyModel", 0, 2, "AllOf");
-    qmlRegisterUncreatableType<FilterContainerAttached>("SortFilterProxyModel", 0, 2, "FilterContainer", "FilterContainer can only be used as an attaching type");
+    qmlRegisterUncreatableType<FilterContainerAttached>("SortFilterProxyModel", 0, 2, "FilterContainer", QStringLiteral("FilterContainer can only be used as an attaching type"));
 }
 
 Q_COREAPP_STARTUP_FUNCTION(registerFiltersTypes)

--- a/filters/rangefilter.cpp
+++ b/filters/rangefilter.cpp
@@ -43,7 +43,7 @@ QVariant RangeFilter::minimumValue() const
     return m_minimumValue;
 }
 
-void RangeFilter::setMinimumValue(QVariant minimumValue)
+void RangeFilter::setMinimumValue(const QVariant &minimumValue)
 {
     if (m_minimumValue == minimumValue)
         return;
@@ -92,7 +92,7 @@ QVariant RangeFilter::maximumValue() const
     return m_maximumValue;
 }
 
-void RangeFilter::setMaximumValue(QVariant maximumValue)
+void RangeFilter::setMaximumValue(const QVariant &maximumValue)
 {
     if (m_maximumValue == maximumValue)
         return;

--- a/filters/rangefilter.h
+++ b/filters/rangefilter.h
@@ -18,12 +18,12 @@ public:
     using RoleFilter::RoleFilter;
 
     QVariant minimumValue() const;
-    void setMinimumValue(QVariant minimumValue);
+    void setMinimumValue(const QVariant &minimumValue);
     bool minimumInclusive() const;
     void setMinimumInclusive(bool minimumInclusive);
 
     QVariant maximumValue() const;
-    void setMaximumValue(QVariant maximumValue);
+    void setMaximumValue(const QVariant &maximumValue);
     bool maximumInclusive() const;
     void setMaximumInclusive(bool maximumInclusive);
 

--- a/filters/regexpfilter.h
+++ b/filters/regexpfilter.h
@@ -19,7 +19,7 @@ public:
         RegExp2 = QRegExp::RegExp2,
         WildcardUnix = QRegExp::WildcardUnix,
         W3CXmlSchema11 = QRegExp::W3CXmlSchema11 };
-    Q_ENUMS(PatternSyntax)
+    Q_ENUM(PatternSyntax)
 
     using RoleFilter::RoleFilter;
 

--- a/proxyroles/expressionrole.cpp
+++ b/proxyroles/expressionrole.cpp
@@ -76,9 +76,9 @@ QVariant ExpressionRole::data(const QModelIndex& sourceIndex, const QQmlSortFilt
 
         for (auto it = roles.cbegin(); it != roles.cend(); ++it)
             addToContext(it.value(), proxyModel.sourceData(sourceIndex, it.key()));
-        addToContext("index", sourceIndex.row());
+        addToContext(QStringLiteral("index"), sourceIndex.row());
 
-        context.setContextProperty("model", modelMap);
+        context.setContextProperty(QStringLiteral("model"), modelMap);
 
         QQmlExpression expression(m_scriptString, &context);
         QVariant result = expression.evaluate();
@@ -89,7 +89,7 @@ QVariant ExpressionRole::data(const QModelIndex& sourceIndex, const QQmlSortFilt
         }
         return result;
     }
-    return QVariant();
+    return {};
 }
 
 void ExpressionRole::updateContext(const QQmlSortFilterProxyModel& proxyModel)
@@ -104,12 +104,13 @@ void ExpressionRole::updateContext(const QQmlSortFilterProxyModel& proxyModel)
         modelMap.insert(name, value);
     };
 
-    for (const QByteArray& roleName : proxyModel.roleNames().values())
+    const auto roleNames = proxyModel.roleNames();
+    for (const QByteArray& roleName : roleNames)
         addToContext(roleName, QVariant());
 
-    addToContext("index", -1);
+    addToContext(QStringLiteral("index"), -1);
 
-    m_context->setContextProperty("model", modelMap);
+    m_context->setContextProperty(QStringLiteral("model"), modelMap);
     updateExpression();
 }
 
@@ -119,7 +120,7 @@ void ExpressionRole::updateExpression()
         return;
 
     delete m_expression;
-    m_expression = new QQmlExpression(m_scriptString, m_context, 0, this);
+    m_expression = new QQmlExpression(m_scriptString, m_context, nullptr, this);
     connect(m_expression, &QQmlExpression::valueChanged, this, &ExpressionRole::invalidate);
     m_expression->setNotifyOnValueChanged(true);
     m_expression->evaluate();

--- a/proxyroles/filterrole.cpp
+++ b/proxyroles/filterrole.cpp
@@ -55,7 +55,7 @@ void FilterRole::onFiltersCleared()
 
 QVariant FilterRole::data(const QModelIndex& sourceIndex, const QQmlSortFilterProxyModel& proxyModel)
 {
-    return std::all_of(m_filters.begin(), m_filters.end(),
+    return std::all_of(m_filters.cbegin(), m_filters.cend(),
         [&] (Filter* filter) {
             return filter->filterAcceptsRow(sourceIndex, proxyModel);
         }

--- a/proxyroles/joinrole.cpp
+++ b/proxyroles/joinrole.cpp
@@ -71,7 +71,7 @@ QVariant JoinRole::data(const QModelIndex &sourceIndex, const QQmlSortFilterProx
 {
     QString result;
 
-    for (const QString& roleName : m_roleNames)
+    for (const QString& roleName : qAsConst(m_roleNames))
         result += proxyModel.sourceData(sourceIndex, roleName).toString() + m_separator;
 
     if (!m_roleNames.isEmpty())

--- a/proxyroles/joinrole.h
+++ b/proxyroles/joinrole.h
@@ -28,7 +28,7 @@ Q_SIGNALS:
 private:
     QStringList m_roleNames;
     QVariant data(const QModelIndex& sourceIndex, const QQmlSortFilterProxyModel& proxyModel) override;
-    QString m_separator = " ";
+    QString m_separator = QStringLiteral(" ");
 };
 
 }

--- a/proxyroles/proxyrole.cpp
+++ b/proxyroles/proxyrole.cpp
@@ -1,11 +1,4 @@
 #include "proxyrole.h"
-#include <QQmlEngine>
-#include <QQmlContext>
-#include <QQmlExpression>
-#include <QCoreApplication>
-#include <QDebug>
-#include <QQmlInfo>
-#include "filters/filter.h"
 #include "qqmlsortfilterproxymodel.h"
 
 namespace qqsfpm {
@@ -28,9 +21,8 @@ QVariant ProxyRole::roleData(const QModelIndex& sourceIndex, const QQmlSortFilte
         QVariant result = data(sourceIndex, proxyModel, name);
         m_mutex.unlock();
         return result;
-    } else {
-        return {};
     }
+    return {};
 }
 
 void ProxyRole::proxyModelCompleted(const QQmlSortFilterProxyModel &proxyModel)

--- a/proxyroles/proxyrolesqmltypes.cpp
+++ b/proxyroles/proxyrolesqmltypes.cpp
@@ -10,7 +10,7 @@
 namespace qqsfpm {
 
 void registerProxyRoleTypes() {
-    qmlRegisterUncreatableType<ProxyRole>("SortFilterProxyModel", 0, 2, "ProxyRole", "ProxyRole is an abstract class");
+    qmlRegisterUncreatableType<ProxyRole>("SortFilterProxyModel", 0, 2, "ProxyRole", QStringLiteral("ProxyRole is an abstract class"));
     qmlRegisterType<JoinRole>("SortFilterProxyModel", 0, 2, "JoinRole");
     qmlRegisterType<SwitchRole>("SortFilterProxyModel", 0, 2, "SwitchRole");
     qmlRegisterType<ExpressionRole>("SortFilterProxyModel", 0, 2, "ExpressionRole");

--- a/proxyroles/switchrole.cpp
+++ b/proxyroles/switchrole.cpp
@@ -50,7 +50,7 @@ QVariant SwitchRoleAttached::value() const
     return m_value;
 }
 
-void SwitchRoleAttached::setValue(QVariant value)
+void SwitchRoleAttached::setValue(const QVariant &value)
 {
     if (m_value == value)
         return;
@@ -113,7 +113,7 @@ void SwitchRole::setDefaultValue(const QVariant& defaultValue)
 
 void SwitchRole::proxyModelCompleted(const QQmlSortFilterProxyModel& proxyModel)
 {
-    for (Filter* filter : m_filters)
+    for (Filter* filter : qAsConst(m_filters))
         filter->proxyModelCompleted(proxyModel);
 }
 
@@ -124,7 +124,7 @@ SwitchRoleAttached* SwitchRole::qmlAttachedProperties(QObject* object)
 
 QVariant SwitchRole::data(const QModelIndex &sourceIndex, const QQmlSortFilterProxyModel &proxyModel)
 {
-    for (auto filter: m_filters) {
+    for (auto filter: qAsConst(m_filters)) {
         if (!filter->enabled())
             continue;
         if (filter->filterAcceptsRow(sourceIndex, proxyModel)) {

--- a/proxyroles/switchrole.h
+++ b/proxyroles/switchrole.h
@@ -3,7 +3,6 @@
 
 #include "singlerole.h"
 #include "filters/filtercontainer.h"
-#include <QtQml>
 
 namespace qqsfpm {
 
@@ -15,7 +14,7 @@ public:
     SwitchRoleAttached(QObject* parent);
 
     QVariant value() const;
-    void setValue(QVariant value);
+    void setValue(const QVariant &value);
 
 Q_SIGNALS:
     void valueChanged();

--- a/qqmlsortfilterproxymodel.cpp
+++ b/qqmlsortfilterproxymodel.cpp
@@ -53,30 +53,6 @@ int QQmlSortFilterProxyModel::count() const
 }
 
 /*!
-    \qmlproperty int SortFilterProxyModel::limit
-
-   Limit the total number of results
-*/
-int QQmlSortFilterProxyModel::limit() const
-{
-    return m_limit;
-}
-
-void QQmlSortFilterProxyModel::setLimit(int newLimit)
-{
-    if (m_limit == newLimit)
-        return;
-
-    const auto prevCount = count();
-    m_limit = newLimit;
-    emit limitChanged();
-
-    if (prevCount != count()) {
-        emit countChanged();
-    }
-}
-
-/*!
     \qmlproperty bool SortFilterProxyModel::delayed
 
     Delay the execution of filters, sorters and proxyRoles until the next event loop.
@@ -256,14 +232,6 @@ QVariant QQmlSortFilterProxyModel::sourceData(const QModelIndex &sourceIndex, in
         return proxyRole->roleData(sourceIndex, *this, proxyRolePair.second);
     else
         return sourceModel()->data(sourceIndex, role);
-}
-
-int QQmlSortFilterProxyModel::rowCount(const QModelIndex& parent) const
-{
-    const auto origLimit = QSortFilterProxyModel::rowCount(parent);
-    if (m_limit == -1)
-        return origLimit;
-    return qMin(m_limit, origLimit);
 }
 
 QVariant QQmlSortFilterProxyModel::data(const QModelIndex &index, int role) const

--- a/qqmlsortfilterproxymodel.cpp
+++ b/qqmlsortfilterproxymodel.cpp
@@ -230,8 +230,8 @@ QVariant QQmlSortFilterProxyModel::sourceData(const QModelIndex &sourceIndex, in
     QPair<ProxyRole*, QString> proxyRolePair = m_proxyRoleMap[role];
     if (ProxyRole* proxyRole = proxyRolePair.first)
         return proxyRole->roleData(sourceIndex, *this, proxyRolePair.second);
-    else
-        return sourceModel()->data(sourceIndex, role);
+
+    return sourceModel()->data(sourceIndex, role);
 }
 
 QVariant QQmlSortFilterProxyModel::data(const QModelIndex &index, int role) const

--- a/qqmlsortfilterproxymodel.h
+++ b/qqmlsortfilterproxymodel.h
@@ -23,7 +23,6 @@ class QQmlSortFilterProxyModel : public QSortFilterProxyModel,
 
     Q_PROPERTY(int count READ count NOTIFY countChanged)
     Q_PROPERTY(bool delayed READ delayed WRITE setDelayed NOTIFY delayedChanged)
-    Q_PROPERTY(int limit READ limit WRITE setLimit NOTIFY limitChanged FINAL)
 
     Q_PROPERTY(QString filterRoleName READ filterRoleName WRITE setFilterRoleName NOTIFY filterRoleNameChanged)
     Q_PROPERTY(QString filterPattern READ filterPattern WRITE setFilterPattern NOTIFY filterPatternChanged)
@@ -94,7 +93,6 @@ public:
     void setSourceModel(QAbstractItemModel *sourceModel) override;
 
 Q_SIGNALS:
-    void limitChanged();
     void countChanged();
     void delayedChanged();
 
@@ -107,7 +105,6 @@ Q_SIGNALS:
     void ascendingSortOrderChanged();
 
 protected:
-    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
     bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
     bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
 
@@ -129,9 +126,6 @@ private Q_SLOTS:
     void invalidateProxyRoles();
 
 private:
-    int limit() const;
-    void setLimit(int newLimit);
-
     QVariantMap modelDataMap(const QModelIndex& modelIndex) const;
 
     void onFilterAppended(Filter* filter) override;
@@ -159,7 +153,6 @@ private:
     bool m_invalidateFilterQueued = false;
     bool m_invalidateQueued = false;
     bool m_invalidateProxyRolesQueued = false;
-    int m_limit{-1};
 };
 
 }

--- a/qqmlsortfilterproxymodel.h
+++ b/qqmlsortfilterproxymodel.h
@@ -44,7 +44,7 @@ public:
         RegExp2 = QRegExp::RegExp2,
         WildcardUnix = QRegExp::WildcardUnix,
         W3CXmlSchema11 = QRegExp::W3CXmlSchema11 };
-    Q_ENUMS(PatternSyntax)
+    Q_ENUM(PatternSyntax)
 
     QQmlSortFilterProxyModel(QObject* parent = 0);
 

--- a/sorters/expressionsorter.cpp
+++ b/sorters/expressionsorter.cpp
@@ -92,20 +92,20 @@ int ExpressionSorter::compare(const QModelIndex& sourceLeft, const QModelIndex& 
             modelLeftMap.insert(it.value(), proxyModel.sourceData(sourceLeft, it.key()));
             modelRightMap.insert(it.value(), proxyModel.sourceData(sourceRight, it.key()));
         }
-        modelLeftMap.insert("index", sourceLeft.row());
-        modelRightMap.insert("index", sourceRight.row());
+        modelLeftMap.insert(QStringLiteral("index"), sourceLeft.row());
+        modelRightMap.insert(QStringLiteral("index"), sourceRight.row());
 
         QQmlExpression expression(m_scriptString, &context);
 
-        context.setContextProperty("modelLeft", modelLeftMap);
-        context.setContextProperty("modelRight", modelRightMap);
+        context.setContextProperty(QStringLiteral("modelLeft"), modelLeftMap);
+        context.setContextProperty(QStringLiteral("modelRight"), modelRightMap);
         if (evaluateBoolExpression(expression))
-                return -1;
+            return -1;
 
-        context.setContextProperty("modelLeft", modelRightMap);
-        context.setContextProperty("modelRight", modelLeftMap);
+        context.setContextProperty(QStringLiteral("modelLeft"), modelRightMap);
+        context.setContextProperty(QStringLiteral("modelRight"), modelLeftMap);
         if (evaluateBoolExpression(expression))
-                return 1;
+            return 1;
     }
     return 0;
 }
@@ -118,15 +118,16 @@ void ExpressionSorter::updateContext(const QQmlSortFilterProxyModel& proxyModel)
     QVariantMap modelLeftMap, modelRightMap;
     // what about roles changes ?
 
-    for (const QByteArray& roleName : proxyModel.roleNames().values()) {
+    const auto roleNames = proxyModel.roleNames();
+    for (const QByteArray& roleName : roleNames) {
         modelLeftMap.insert(roleName, QVariant());
         modelRightMap.insert(roleName, QVariant());
     }
-    modelLeftMap.insert("index", -1);
-    modelRightMap.insert("index", -1);
+    modelLeftMap.insert(QStringLiteral("index"), -1);
+    modelRightMap.insert(QStringLiteral("index"), -1);
 
-    m_context->setContextProperty("modelLeft", modelLeftMap);
-    m_context->setContextProperty("modelRight", modelRightMap);
+    m_context->setContextProperty(QStringLiteral("modelLeft"), modelLeftMap);
+    m_context->setContextProperty(QStringLiteral("modelRight"), modelRightMap);
 
     updateExpression();
 }
@@ -137,7 +138,7 @@ void ExpressionSorter::updateExpression()
         return;
 
     delete m_expression;
-    m_expression = new QQmlExpression(m_scriptString, m_context, 0, this);
+    m_expression = new QQmlExpression(m_scriptString, m_context, nullptr, this);
     connect(m_expression, &QQmlExpression::valueChanged, this, &ExpressionSorter::invalidate);
     m_expression->setNotifyOnValueChanged(true);
     m_expression->evaluate();

--- a/sorters/filtersorter.cpp
+++ b/sorters/filtersorter.cpp
@@ -48,7 +48,7 @@ int FilterSorter::compare(const QModelIndex& sourceLeft, const QModelIndex& sour
 
 void FilterSorter::proxyModelCompleted(const QQmlSortFilterProxyModel& proxyModel)
 {
-    for (Filter* filter : m_filters)
+    for (Filter* filter : qAsConst(m_filters))
         filter->proxyModelCompleted(proxyModel);
 }
 

--- a/sorters/sortercontainer.h
+++ b/sorters/sortercontainer.h
@@ -3,7 +3,7 @@
 
 #include <QList>
 #include <QQmlListProperty>
-#include <qqml.h>
+#include <QQmlEngine>
 #include <QPointer>
 
 namespace qqsfpm {

--- a/sorters/sortersqmltypes.cpp
+++ b/sorters/sortersqmltypes.cpp
@@ -10,12 +10,12 @@
 namespace qqsfpm {
 
 void registerSorterTypes() {
-    qmlRegisterUncreatableType<Sorter>("SortFilterProxyModel", 0, 2, "Sorter", "Sorter is an abstract class");
+    qmlRegisterUncreatableType<Sorter>("SortFilterProxyModel", 0, 2, "Sorter", QStringLiteral("Sorter is an abstract class"));
     qmlRegisterType<RoleSorter>("SortFilterProxyModel", 0, 2, "RoleSorter");
     qmlRegisterType<StringSorter>("SortFilterProxyModel", 0, 2, "StringSorter");
     qmlRegisterType<FilterSorter>("SortFilterProxyModel", 0, 2, "FilterSorter");
     qmlRegisterType<ExpressionSorter>("SortFilterProxyModel", 0, 2, "ExpressionSorter");
-    qmlRegisterUncreatableType<SorterContainerAttached>("SortFilterProxyModel", 0, 2, "SorterContainer", "SorterContainer can only be used as an attaching type");
+    qmlRegisterUncreatableType<SorterContainerAttached>("SortFilterProxyModel", 0, 2, "SorterContainer", QStringLiteral("SorterContainer can only be used as an attaching type"));
 }
 
 Q_COREAPP_STARTUP_FUNCTION(registerSorterTypes)


### PR DESCRIPTION
- revert `limit` property
- complete the previous clazy fixes (should result in speedups in some cases)