### PR TITLE
Prevent disconnecting `modelReset` when the same `sourceModel` is set

### DIFF
--- a/qqmlsortfilterproxymodel.cpp
+++ b/qqmlsortfilterproxymodel.cpp
@@ -399,6 +399,9 @@ void QQmlSortFilterProxyModel::setSourceModel(QAbstractItemModel *sourceModel)
     // SFPM creation or after source model reset it's necessary to re-initialize
     // role names if the source was empty before insertion.
 
+    if (this->sourceModel() == sourceModel)
+        return;
+
     if (auto currentSource = this->sourceModel()) {
         disconnect(currentSource, &QAbstractItemModel::rowsInserted, this,
                    &QQmlSortFilterProxyModel::initRoles);


### PR DESCRIPTION
Solution for proper handling QTBUG-57971 (https://github.com/status-im/SortFilterProxyModel/pull/5) introduced bug causing that `modelReset` is not emitted after calling `setSourceModel` with the same source as the one currently set. This PR fixed the problem.