### PR TITLE
`RegExpFilter` msvc compilation fix

### DIFF
--- a/filters/regexpfilter.cpp
+++ b/filters/regexpfilter.cpp
@@ -35,9 +35,10 @@ namespace qqsfpm {
 
     \sa syntax
 */
-RegExpFilter::RegExpFilter() :
-    m_caseSensitivity(m_regExp.patternOptions().testFlag(
-        QRegularExpression::CaseInsensitiveOption) ? Qt::CaseInsensitive : Qt::CaseSensitive)
+RegExpFilter::RegExpFilter(QObject *parent)
+    : RoleFilter(parent), m_caseSensitivity(
+          m_regExp.patternOptions().testFlag(
+              QRegularExpression::CaseInsensitiveOption) ? Qt::CaseInsensitive : Qt::CaseSensitive)
 {
 }
 

--- a/filters/regexpfilter.h
+++ b/filters/regexpfilter.h
@@ -20,9 +20,7 @@ public:
         FixedString };
     Q_ENUM(PatternSyntax)
 
-    using RoleFilter::RoleFilter;
-
-    RegExpFilter();
+    explicit RegExpFilter(QObject *parent = nullptr);
 
     QString pattern() const;
     void setPattern(const QString& pattern);


### PR DESCRIPTION
Fixes MSVC compilation broken by colliding constructors in `RegExpFilter`