### PR TITLE
Handling of QTBUG-57971 improved by converting role-changing initial insert to model reset

### DIFF
--- a/qqmlsortfilterproxymodel.cpp
+++ b/qqmlsortfilterproxymodel.cpp
@@ -363,49 +363,57 @@ void QQmlSortFilterProxyModel::resetInternalData()
 
 void QQmlSortFilterProxyModel::setSourceModel(QAbstractItemModel *sourceModel)
 {
+    if (this->sourceModel() == sourceModel)
+        return;
+
+    QSortFilterProxyModel::setSourceModel(sourceModel);
+
     // QML built-in type ListModel behaves in a specific way regarding roles
     // initialization (QTBUG-57971). Empty model has no roles, they become
     // available after first insertion. However modelAboutToBeReset/modelReset
     // is not emited. It means that roles may change not only in between model
     // resets but also on the first insertion.
-    // In a simple case, where ListModel (or other model behaving in that way)
-    // is direct source of SFPM, situation is relatively simple - if source
-    // has no roles, SFPM should try to initialize them on first insertion
-    // However this behavior has far-reaching consequences, because the
-    // ListModel-like model may not be a direct source for SFPM. E.g. there may
-    // by another SFPM in between, with proxy roles defined:
     //
-    // ListModel -> SFPM 1 (with proxy roles) -> SFPM 2
-    //
-    // In such scenario SFPM 2 will always have model with roles as it's source
-    // (at least proxy roles). It means that on first insertion right after
-    // SFPM creation or after source model reset it's necessary to re-initialize
-    // role names if the source was empty before insertion.
+    // The provided workaround causes that initial insert initializing roles in
+    // ListModel is converted into a model reset emited from SFPM. Thanks to
+    // that the roles are not only correctly initialized but also the issue is
+    // no longer propagated to other proxies using SFPM as it's source (because
+    // SFPM will emit model reset instead of insertions signals in that special
+    // case).
+    auto disconnect = [this] {
+        delete m_qtbug_57971_signalsContext;
+        m_qtbug_57971_signalsContext = nullptr;
+    };
 
-    if (this->sourceModel() == sourceModel)
-        return;
+    disconnect();
 
-    if (auto currentSource = this->sourceModel()) {
-        disconnect(currentSource, &QAbstractItemModel::rowsInserted, this,
-                   &QQmlSortFilterProxyModel::initRoles);
-        disconnect(currentSource, &QAbstractItemModel::modelReset, this, nullptr);
-    }
+    if (sourceModel && sourceModel->roleNames().isEmpty()
+        && sourceModel->rowCount() == 0) {
 
-    if (sourceModel && sourceModel->rowCount() == 0)
-        connect(sourceModel, &QAbstractItemModel::rowsInserted, this,
-                &QQmlSortFilterProxyModel::initRoles, Qt::UniqueConnection);
+        auto& ctx = m_qtbug_57971_signalsContext;
+        ctx = new QObject(this);
 
-    if (sourceModel) {
-        connect(sourceModel, &QAbstractItemModel::modelReset, this, [sourceModel, this]() {
-            if (sourceModel->rowCount() != 0)
-                return;
+        using QAIM = QAbstractItemModel;
 
-            connect(sourceModel, &QAbstractItemModel::rowsInserted, this,
-                    &QQmlSortFilterProxyModel::initRoles, Qt::UniqueConnection);
+        connect(sourceModel, &QAIM::rowsAboutToBeInserted, ctx, [this] () {
+            this->beginResetModel();
+            this->blockSignals(true);
+        });
+
+        connect(sourceModel, &QAIM::rowsInserted, ctx, [this, disconnect] () {
+            this->blockSignals(false);
+            this->initRoles();
+            this->endResetModel();
+
+            disconnect();
+        });
+
+        connect(sourceModel, &QAIM::modelReset, ctx, [this, disconnect] () {
+            if (!this->sourceModel()->roleNames().isEmpty()
+                || this->sourceModel()->rowCount() != 0)
+                disconnect();
         });
     }
-
-    QSortFilterProxyModel::setSourceModel(sourceModel);
 }
 
 void QQmlSortFilterProxyModel::queueInvalidateFilter()

--- a/qqmlsortfilterproxymodel.h
+++ b/qqmlsortfilterproxymodel.h
@@ -139,6 +139,8 @@ private:
     bool m_invalidateFilterQueued = false;
     bool m_invalidateQueued = false;
     bool m_invalidateProxyRolesQueued = false;
+
+    QObject* m_qtbug_57971_signalsContext = nullptr;
 };
 
 }

--- a/tests/tst_builtins.qml
+++ b/tests/tst_builtins.qml
@@ -12,12 +12,26 @@ Item {
         ListElement{role1: 4; role2: 2}
     }
     ListModel {
-        id: noRolesFirstTestModel
+        id: noRolesFirstTestModel_1
         function initModel() {
-            noRolesFirstTestModel.append({role1: 1, role2: 1 })
-            noRolesFirstTestModel.append({role1: 2, role2: 1 })
-            noRolesFirstTestModel.append({role1: 3, role2: 2 })
-            noRolesFirstTestModel.append({role1: 4, role2: 2 })
+            append({role1: 1, role2: 1 })
+            append({role1: 2, role2: 1 })
+            append({role1: 3, role2: 2 })
+            append({role1: 4, role2: 2 })
+        }
+    }
+    ListModel {
+        id: noRolesFirstTestModel_2
+        function initModel() {
+            append({role1: 3, role2: 2 })
+            append({role1: 4, role2: 2 })
+        }
+    }
+    ListModel {
+        id: noRolesFirstTestModel_3
+        function initModel() {
+            append({role1: 3, role2: 2 })
+            append({role1: 4, role2: 2 })
         }
     }
     SortFilterProxyModel {
@@ -31,15 +45,50 @@ Item {
     SortFilterProxyModel {
         id: noRolesFirstTestProxyModel
         property string tag: "noRolesFirstTestProxyModel"
-        sourceModel: noRolesFirstTestModel
+        sourceModel: noRolesFirstTestModel_1
         filterRoleName: "role2"
         filterValue: 2
         property var expectedData: ([{role1: 3, role2: 2}, {role1: 4, role2: 2}])
     }
+    SortFilterProxyModel {
+        id: noRolesFirstTestProxyModelWithProxyRoles
+        property string tag: "noRolesFirstTestProxyModelWithProxyRoles"
+        sourceModel: noRolesFirstTestModel_2
+        property var expectedData: ([{role1: 3, role2: 2, proxyRole: 42}, {role1: 4, role2: 2, proxyRole: 42}])
+
+        proxyRoles: ExpressionRole {
+            name: "proxyRole"
+            expression: 42
+        }
+    }
+    SortFilterProxyModel {
+        id: noRolesFirstTestProxyModelWithProxyRolesNested
+        property string tag: "noRolesFirstTestProxyModelWithProxyRolesNested"
+
+        property var nested: SortFilterProxyModel {
+            id: nested
+
+            function initModel() {
+                sourceModel.initModel();
+            }
+
+            sourceModel: noRolesFirstTestModel_3
+
+            proxyRoles: ExpressionRole {
+                name: "proxyRole"
+                expression: 42
+            }
+        }
+
+        sourceModel: nested
+        property var expectedData: ([{role1: 3, role2: 2, proxyRole: 42}, {role1: 4, role2: 2, proxyRole: 42}])
+    }
     TestCase {
         name: "BuiltinsFilterTests"
         function test_filterValue_data() {
-            return [testProxyModel, noRolesFirstTestProxyModel];
+            return [testProxyModel, noRolesFirstTestProxyModel,
+                    noRolesFirstTestProxyModelWithProxyRoles,
+                    noRolesFirstTestProxyModelWithProxyRolesNested];
         }
 
         function test_filterValue(proxyModel) {
@@ -48,6 +97,7 @@ Item {
             var data = [];
             for (var i = 0; i < proxyModel.count; i++)
                 data.push(proxyModel.get(i));
+
             compare(data, proxyModel.expectedData);
         }
     }


### PR DESCRIPTION
# What does this PR do

The upstream SFPM provides simple fix for `QTBUG-57971` however it doesn't work correctly when multiple SFPMs with proxy roles are used together. It was fixed by providing more complex and complete solution but was still far from perfect - it was forwarding the problem to other proxy roles potentially used in the chain. Because of that other proxies would have to handle not only original `QTBUG-57971` but also variant of that issue created by SFPM where initial roles are defined by proxy roles and then changed at first insertion to empty source model.

The new approach handles the issue internally as previous solutions, but additionally prevents propagation of the problem upstream in more complex flows. The malformed insertion changing roles is converted into modelReset.